### PR TITLE
Input shaping menu shows X frequency for Y

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -3304,7 +3304,7 @@ void Draw_Tune_Menu() {
         MENU_ITEM(ICON_ShapingX, MSG_SHAPING_A_ZETA, onDrawShapingXZeta, SetShapingXZeta);
       #endif
       #if ENABLED(INPUT_SHAPING_Y)
-        MENU_ITEM(ICON_ShapingY, MSG_SHAPING_B_FREQ, onDrawShapingXFreq, SetShapingYFreq);
+        MENU_ITEM(ICON_ShapingY, MSG_SHAPING_B_FREQ, onDrawShapingYFreq, SetShapingYFreq);
         MENU_ITEM(ICON_ShapingY, MSG_SHAPING_B_ZETA, onDrawShapingYZeta, SetShapingYZeta);
       #endif
     }


### PR DESCRIPTION
### Description

Fixes showing Y frequency in input shaping menu

### Related Issues

https://github.com/classicrocker883/MriscocProUI/issues/21
