### PR TITLE
Fix base64 input length check for 256-byte preview chunks

### DIFF
--- a/Marlin/src/lcd/dwin/proui/base64.h
+++ b/Marlin/src/lcd/dwin/proui/base64.h
@@ -19,7 +19,7 @@
  *     ascii code of base64 character. If byte is >= 64, then there is not corresponding base64 character
  *     and 255 is returned
  */
-unsigned char binary_to_base64(unsigned char v);
+uint8_t binary_to_base64(uint8_t v);
 
 /* base64_to_binary:
  *   Description:
@@ -29,7 +29,7 @@ unsigned char binary_to_base64(unsigned char v);
  *   Returns:
  *     6-bit binary value
  */
-unsigned char base64_to_binary(unsigned char c);
+uint8_t base64_to_binary(uint8_t c);
 
 /* encode_base64_length:
  *   Description:
@@ -51,8 +51,8 @@ uint16_t encode_base64_length(uint16_t input_length);
  *   Returns:
  *     Number of bytes of binary data in input
  */
-uint16_t decode_base64_length(unsigned char input[]);
-uint16_t decode_base64_length(unsigned char input[], uint16_t input_length);
+uint16_t decode_base64_length(uint8_t input[]);
+uint16_t decode_base64_length(uint8_t input[], uint16_t input_length);
 
 /* encode_base64:
  *   Description:
@@ -64,7 +64,7 @@ uint16_t decode_base64_length(unsigned char input[], uint16_t input_length);
  *   Returns:
  *     Length of encoded string in bytes (not including null terminator)
  */
-uint16_t encode_base64(unsigned char input[], uint16_t input_length, unsigned char output[]);
+uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]);
 
 /* decode_base64:
  *   Description:
@@ -76,10 +76,10 @@ uint16_t encode_base64(unsigned char input[], uint16_t input_length, unsigned ch
  *   Returns:
  *     Number of bytes in the decoded binary
  */
-uint16_t decode_base64(unsigned char input[], unsigned char output[]);
-uint16_t decode_base64(unsigned char input[], uint16_t input_length, unsigned char output[]);
+uint16_t decode_base64(uint8_t input[], uint8_t output[]);
+uint16_t decode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]);
 
-unsigned char binary_to_base64(unsigned char v) {
+uint8_t binary_to_base64(uint8_t v) {
   // Capital letters - 'A' is ascii 65 and base64 0
   if (v < 26) return v + 'A';
 
@@ -98,7 +98,7 @@ unsigned char binary_to_base64(unsigned char v) {
   return 64;
 }
 
-unsigned char base64_to_binary(unsigned char c) {
+uint8_t base64_to_binary(uint8_t c) {
   // Capital letters - 'A' is ascii 65 and base64 0
   if ('A' <= c && c <= 'Z') return c - 'A';
 
@@ -121,12 +121,12 @@ uint16_t encode_base64_length(uint16_t input_length) {
   return (input_length + 2)/3*4;
 }
 
-uint16_t decode_base64_length(unsigned char input[]) {
+uint16_t decode_base64_length(uint8_t input[]) {
   return decode_base64_length(input, -1);
 }
 
-uint16_t decode_base64_length(unsigned char input[], uint16_t input_length) {
-  unsigned char *start = input;
+uint16_t decode_base64_length(uint8_t input[], uint16_t input_length) {
+  uint8_t *start = input;
 
   while ((uint16_t)(input - start) < input_length && base64_to_binary(input[0]) < 64) {
     ++input;
@@ -136,7 +136,7 @@ uint16_t decode_base64_length(unsigned char input[], uint16_t input_length) {
   return input_length / 4 * 3 + (input_length % 4 ? input_length % 4 - 1 : 0);
 }
 
-uint16_t encode_base64(unsigned char input[], uint16_t input_length, unsigned char output[]) {
+uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]) {
   uint16_t full_sets = input_length / 3;
 
   // While there are still full sets of 24 bits...
@@ -173,11 +173,11 @@ uint16_t encode_base64(unsigned char input[], uint16_t input_length, unsigned ch
   return encode_base64_length(input_length);
 }
 
-uint16_t decode_base64(unsigned char input[], unsigned char output[]) {
+uint16_t decode_base64(uint8_t input[], uint8_t output[]) {
   return decode_base64(input, -1, output);
 }
 
-uint16_t decode_base64(unsigned char input[], uint16_t input_length, unsigned char output[]) {
+uint16_t decode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]) {
   uint16_t output_length = decode_base64_length(input, input_length);
 
   // While there are still full sets of 24 bits...

--- a/Marlin/src/lcd/dwin/proui/base64.h
+++ b/Marlin/src/lcd/dwin/proui/base64.h
@@ -19,7 +19,7 @@
  *     ascii code of base64 character. If byte is >= 64, then there is not corresponding base64 character
  *     and 255 is returned
  */
-uint8_t binary_to_base64(uint8_t v);
+inline uint8_t binary_to_base64(uint8_t v);
 
 /* base64_to_binary:
  *   Description:
@@ -29,7 +29,7 @@ uint8_t binary_to_base64(uint8_t v);
  *   Returns:
  *     6-bit binary value
  */
-uint8_t base64_to_binary(uint8_t c);
+inline uint8_t base64_to_binary(uint8_t c);
 
 /* encode_base64_length:
  *   Description:
@@ -39,7 +39,7 @@ uint8_t base64_to_binary(uint8_t c);
  *   Returns:
  *     Number of base64 characters needed to encode input_length bytes of binary data
  */
-uint16_t encode_base64_length(uint16_t input_length);
+inline uint16_t encode_base64_length(uint16_t input_length);
 
 /* decode_base64_length:
  *   Description:
@@ -51,8 +51,8 @@ uint16_t encode_base64_length(uint16_t input_length);
  *   Returns:
  *     Number of bytes of binary data in input
  */
-uint16_t decode_base64_length(uint8_t input[]);
-uint16_t decode_base64_length(uint8_t input[], uint16_t input_length);
+inline uint16_t decode_base64_length(uint8_t input[]);
+inline uint16_t decode_base64_length(uint8_t input[], uint16_t input_length);
 
 /* encode_base64:
  *   Description:
@@ -64,7 +64,7 @@ uint16_t decode_base64_length(uint8_t input[], uint16_t input_length);
  *   Returns:
  *     Length of encoded string in bytes (not including null terminator)
  */
-uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]);
+inline uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]);
 
 /* decode_base64:
  *   Description:
@@ -76,10 +76,10 @@ uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[])
  *   Returns:
  *     Number of bytes in the decoded binary
  */
-uint16_t decode_base64(uint8_t input[], uint8_t output[]);
-uint16_t decode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]);
+inline uint16_t decode_base64(uint8_t input[], uint8_t output[]);
+inline uint16_t decode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]);
 
-uint8_t binary_to_base64(uint8_t v) {
+inline uint8_t binary_to_base64(uint8_t v) {
   // Capital letters - 'A' is ascii 65 and base64 0
   if (v < 26) return v + 'A';
 
@@ -95,10 +95,10 @@ uint8_t binary_to_base64(uint8_t v) {
   // '/' is ascii 47 and base64 63
   if (v == 63) return '/';
 
-  return 64;
+  return 255;
 }
 
-uint8_t base64_to_binary(uint8_t c) {
+inline uint8_t base64_to_binary(uint8_t c) {
   // Capital letters - 'A' is ascii 65 and base64 0
   if ('A' <= c && c <= 'Z') return c - 'A';
 
@@ -117,15 +117,15 @@ uint8_t base64_to_binary(uint8_t c) {
   return 255;
 }
 
-uint16_t encode_base64_length(uint16_t input_length) {
-  return (input_length + 2)/3*4;
+inline uint16_t encode_base64_length(uint16_t input_length) {
+  return (input_length + 2) / 3 * 4;
 }
 
-uint16_t decode_base64_length(uint8_t input[]) {
-  return decode_base64_length(input, -1);
+inline uint16_t decode_base64_length(uint8_t input[]) {
+  return decode_base64_length(input, UINT16_MAX);
 }
 
-uint16_t decode_base64_length(uint8_t input[], uint16_t input_length) {
+inline uint16_t decode_base64_length(uint8_t input[], uint16_t input_length) {
   uint8_t *start = input;
 
   while ((uint16_t)(input - start) < input_length && base64_to_binary(input[0]) < 64) {
@@ -136,7 +136,7 @@ uint16_t decode_base64_length(uint8_t input[], uint16_t input_length) {
   return input_length / 4 * 3 + (input_length % 4 ? input_length % 4 - 1 : 0);
 }
 
-uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]) {
+inline uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]) {
   uint16_t full_sets = input_length / 3;
 
   // While there are still full sets of 24 bits...
@@ -173,11 +173,11 @@ uint16_t encode_base64(uint8_t input[], uint16_t input_length, uint8_t output[])
   return encode_base64_length(input_length);
 }
 
-uint16_t decode_base64(uint8_t input[], uint8_t output[]) {
-  return decode_base64(input, -1, output);
+inline uint16_t decode_base64(uint8_t input[], uint8_t output[]) {
+  return decode_base64(input, UINT16_MAX, output);
 }
 
-uint16_t decode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]) {
+inline uint16_t decode_base64(uint8_t input[], uint16_t input_length, uint8_t output[]) {
   uint16_t output_length = decode_base64_length(input, input_length);
 
   // While there are still full sets of 24 bits...

--- a/Marlin/src/lcd/dwin/proui/base64.h
+++ b/Marlin/src/lcd/dwin/proui/base64.h
@@ -128,7 +128,7 @@ uint16_t decode_base64_length(unsigned char input[]) {
 uint16_t decode_base64_length(unsigned char input[], uint16_t input_length) {
   unsigned char *start = input;
 
-  while (base64_to_binary(input[0]) < 64 && (unsigned char)(input - start) < input_length) {
+  while ((uint16_t)(input - start) < input_length && base64_to_binary(input[0]) < 64) {
     ++input;
   }
 


### PR DESCRIPTION
### Description

This PR fixes an out-of-bounds read in `decode_base64_length()` in:

`Marlin/src/lcd/dwin/proui/base64.h`

<details>
<summary>Click to open</summary>
The issue became relevant after commit `ae1b0d8` (`Update - improve gcode_preview, add change filament to toolbar, std::min`), where G-code thumbnail Base64 data is decoded in fixed-size chunks:

```cpp
const uint16_t ENC_CHUNK = 256;
```

Full thumbnail chunks are therefore passed to `decode_base64()` with an `input_length` of exactly `256`.

The previous condition in `decode_base64_length()` was:

```cpp
while (base64_to_binary(input[0]) < 64 && (unsigned char)(input - start) < input_length) {
```

There are two problems with this condition:

1. `(input - start)` is cast to `unsigned char`, which can only represent values from `0` to `255`.

   When the offset reaches `256`, the cast wraps it back to `0`, so the length check does not correctly stop at the end of a 256-byte input buffer.

2. The Base64 character is checked before the input boundary:

   ```cpp
   base64_to_binary(input[0])
   ```

   Because `&&` is evaluated left-to-right, `input[0]` may be read before confirming that `input` is still inside the supplied buffer.

The condition is changed to:

```cpp
while ((uint16_t)(input - start) < input_length && base64_to_binary(input[0]) < 64) {
```

This ensures that:

- the input offset can correctly represent `256`;
- the buffer boundary is checked first;
- `input[input_length]` is never read;
- normal Base64 decoding behavior is otherwise unchanged.

No changes to the thumbnail format, dimensions, image rendering, or DWIN SRAM transfer logic are introduced.

The issue was identified during an AI-assisted code review. The proposed fix was then manually reviewed, compiled, and tested on an Ender-3 S1 with real 200x200 G-code thumbnails.
</details>

### Requirements
<details>
<summary>Click to open</summary>
The issue is exposed by the current DWIN ProUI G-code preview implementation when:
- `DWIN_LCD_PROUI` is enabled;
- `HAS_GCODE_PREVIEW` is enabled;
- thumbnail Base64 data contains one or more full 256-byte chunks.

No specific controller board is required for the fix itself.

The change was tested on:
- Creality Ender-3 S1
- STM32F401RE
- `STM32F401RE_creality` PlatformIO environment
- DACAI DWIN display
- 200x200 G-code thumbnails
</details>

### Benefits
<details>
<summary>Click to open</summary>
Prevents an out-of-bounds read when decoding full 256-byte Base64 chunks used by the current G-code preview implementation.

Previously, preview images could still appear correctly because the byte located immediately after the input buffer often happened to contain a value that was not a valid Base64 character. In that case the decoder stopped and produced the expected result, masking the bug.

However, the behavior depended on data outside the supplied input buffer and therefore was not reliable.

With this fix:
- the Base64 decoder respects the supplied input length;
- 256-byte chunks are handled correctly;
- decoding no longer depends on adjacent memory contents;
- existing working G-code previews continue to display normally.

A real 200x200 thumbnail with `7676` Base64 characters was tested. It contains:
- 29 full chunks of 256 characters;
- one final chunk of 252 characters.

The preview continues to decode and display correctly after this change.
</details>

### Configurations
<details>
<summary>Click to open</summary>
No configuration changes are required.

Test configuration:
- Ender-3 S1
- STM32F401RE
- `STM32F401RE_creality`
- `DWIN_LCD_PROUI`
- `DACAI_DISPLAY`
- G-code Preview enabled
- 200x200 thumbnail

No additional configuration ZIP should be necessary because this PR only changes the bounds check in the shared Base64 decoder.
</details>

### Related Issues
No existing Issue is known.
Related commit that introduced 256-byte chunked thumbnail decoding:
`ae1b0d8` - `Update - improve gcode_preview, add change filament to toolbar, std::min`
