### PR TITLE
Fix Tramming Wizard popup icon on DACAI displays

### DIFF
--- a/Marlin/src/lcd/dwin/proui/dwin.cpp
+++ b/Marlin/src/lcd/dwin/proui/dwin.cpp
@@ -3060,7 +3060,7 @@ TERN(HAS_BED_PROBE, float, void) tram(uint8_t point OPTARG(HAS_BED_PROBE, bool s
   }
 
   // Trammingwizard Popup
-  void PopUp_StartTramwiz() { Popup_ConfirmCancel(TERN(TJC_DISPLAY, ICON_BLTouch, ICON_Printer_0), GET_TEXT_F(MSG_TRAMMING_WIZARD_POPUP)); }
+  void PopUp_StartTramwiz() { Popup_ConfirmCancel(HOME_AND_KILL_ICON, GET_TEXT_F(MSG_TRAMMING_WIZARD_POPUP)); }
   void OnClick_StartTramwiz() {
     if (HMI_flag.select_flag) {
       if (HMI_data.FullManualTramming) {


### PR DESCRIPTION
### Description
This PR fixes an incorrect graphic displayed in the **Tramming Wizard** popup when using a DACAI DWIN display.
<details>
<summary>Click to open</summary>
The Tramming Wizard popup currently selects its icon with:

```cpp
TERN(TJC_DISPLAY, ICON_BLTouch, ICON_Printer_0)
```
This handles `TJC_DISPLAY`, but does not account for `DACAI_DISPLAY`.

As a result, DACAI displays use `ICON_Printer_0`, which can resolve to an incompatible display resource. On a DACAI display this caused the Tramming Wizard popup to show an unrelated Chinese message:

> 存储卡被拔出, 请插入存储点击确认

The same display compatibility is already handled elsewhere in `dwin.cpp` by:

```cpp
#if ANY(TJC_DISPLAY, DACAI_DISPLAY)
  #define HOME_AND_KILL_ICON ICON_BLTouch
#else
  #define HOME_AND_KILL_ICON ICON_Printer_0
#endif
```
The Tramming Wizard popup is therefore changed to use the existing `HOME_AND_KILL_ICON` definition instead of duplicating an incomplete display check.

The change is:

```cpp
void PopUp_StartTramwiz() { Popup_ConfirmCancel(HOME_AND_KILL_ICON, GET_TEXT_F(MSG_TRAMMING_WIZARD_POPUP)); }
```
The fix was compiled and tested on an Ender-3 S1 with a DACAI display. After the change, the incorrect Chinese graphic no longer appears in the Tramming Wizard popup.
</details>

### Requirements
The issue applies when:
- `DWIN_LCD_PROUI` is enabled;
- `DACAI_DISPLAY` is enabled;
- a bed probe is available;
- `PROUI_ITEM_TRAM` is enabled.

No additional hardware or configuration changes are required.

### Benefits
- Fixes the incorrect Chinese graphic shown in the Tramming Wizard popup on DACAI displays.
- Reuses the existing `HOME_AND_KILL_ICON` display compatibility logic.
- Keeps DACAI and TJC displays on the already-supported `ICON_BLTouch` resource.
- Avoids duplicating display-specific icon-selection logic.
- Does not change Tramming Wizard behavior or probing logic.

### Configurations
No configuration changes are required.

Test configuration:

- Creality Ender-3 S1
- `DWIN_LCD_PROUI`
- `DACAI_DISPLAY`
- `PROUI_ITEM_TRAM`
- CR-Touch / bed probe

The Tramming Wizard was tested before and after the change. The incorrect Chinese graphic was present before the fix and no longer appears after applying it.

### Related Issues
No existing Issue is known.
This is similar to the existing DACAI handling used by `HOME_AND_KILL_ICON` for other popups such as Auto Home.